### PR TITLE
use separate Dockerfile to set VITE_API_URL

### DIFF
--- a/client/local.Dockerfile
+++ b/client/local.Dockerfile
@@ -6,10 +6,6 @@ RUN npm install
 RUN npm install esbuild@0.25.4 --save-exact
 RUN npm i -g serve
 COPY . .
-
-# Sets the API URL to the value of the VITE_API_URL environment variable
-RUN mv .env.production.example .env.production
-
 RUN npm run build
 EXPOSE 3000
 CMD [ "serve", "-s", "dist" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,11 +2,9 @@ services:
   client:
     build:
       context: ./client
-      dockerfile: Dockerfile
+      dockerfile: local.Dockerfile
     ports:
       - "5173:3000"
-    environment:
-      - VITE_API_URL=https://closed-ai.student.k8s.aet.cit.tum.de/
 
   traefik:
     image: traefik:v3.4.1


### PR DESCRIPTION
Basically the VITE_API_URL variable can't be set after the Docker image has been built, this means that the ENV var can't be configured in K8S in a config map.