### PR TITLE
`Tests`: Add and Improve JaCoCo Coverage & Reporting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,12 +24,9 @@ jobs:
   lint-server:
     name: Check Server Code with Spotless
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        service: [project, task, user]
     defaults:
       run:
-        working-directory: server/${{ matrix.service }}-service
+        working-directory: server
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java
@@ -38,7 +35,7 @@ jobs:
           distribution: "temurin"
           java-version: "21"
       - name: Run Spotless Check
-        run: ../gradlew spotlessCheck
+        run: ./gradlew spotlessCheck
 
   lint-genai:
     name: Check GenAI Code with Black

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,21 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build with Gradle
-        run: cd server && ./gradlew test
+      - name: Test with Gradle and Check Coverage
+        run: cd server && ./gradlew check
+
+      - name: Generate JaCoCo Reports
+        if: always()
+        run: cd server && ./gradlew jacocoTestReport
+
+      - name: Upload JaCoCo Coverage Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: |
+            server/user-service/build/reports/jacoco/
+            server/project-service/build/reports/jacoco/
+            server/task-service/build/reports/jacoco/
+
+# server/common/build/reports/jacoco/ TODO: Add tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,4 @@ jobs:
             server/user-service/build/reports/jacoco/
             server/project-service/build/reports/jacoco/
             server/task-service/build/reports/jacoco/
-
-# server/common/build/reports/jacoco/ TODO: Add tests
+            server/common/build/reports/jacoco/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Test with Gradle and Check Coverage
-        run: cd server && ./gradlew check
+        run: cd server && ./gradlew test jacocoTestCoverageVerification -x spotlessCheck -x spotlessApply
 
       - name: Generate JaCoCo Reports
         if: always()

--- a/server/common/build.gradle
+++ b/server/common/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     // Monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    
+    // Testing
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation 'org.mockito:mockito-core'
 }
 
 test {

--- a/server/common/build.gradle
+++ b/server/common/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'de.tum.cit.aet.closed.ai'
@@ -36,4 +37,27 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.7
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/AddTaskDtoTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/AddTaskDtoTest.java
@@ -1,0 +1,53 @@
+package de.tum.cit.aet.closed.ai.dto;
+
+import de.tum.cit.aet.closed.ai.model.TaskStatus;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AddTaskDtoTest {
+
+    @Test
+    void testAddTaskDtoWithAllFields() {
+        // Given
+        String title = "Task Title";
+        String description = "Task Description";
+        TaskStatus status = TaskStatus.OPEN;
+        Long assigneeId = 1L;
+
+        // When
+        AddTaskDto dto = new AddTaskDto(title, description, status, assigneeId);
+
+        // Then
+        assertEquals(title, dto.title(), "Title should match the input");
+        assertEquals(description, dto.description(), "Description should match the input");
+        assertEquals(status, dto.taskStatus(), "Task status should match the input");
+        assertEquals(assigneeId, dto.assigneeId(), "Assignee ID should match the input");
+    }
+
+    @Test
+    void testAddTaskDtoDefaultStatusWhenNull() {
+        // Given
+        String title = "Task Title";
+        String description = "Task Description";
+        Long assigneeId = 1L;
+
+        // When
+        AddTaskDto dto = new AddTaskDto(title, description, null, assigneeId);
+
+        // Then
+        assertEquals(TaskStatus.BACKLOG, dto.taskStatus(),
+                "Task status should default to BACKLOG when null is provided");
+    }
+
+    @Test
+    void testEquality() {
+        // Given
+        AddTaskDto dto1 = new AddTaskDto("Task 1", "Description", TaskStatus.OPEN, 1L);
+        AddTaskDto dto2 = new AddTaskDto("Task 1", "Description", TaskStatus.OPEN, 1L);
+        AddTaskDto dto3 = new AddTaskDto("Task 2", "Description", TaskStatus.OPEN, 1L);
+
+        // Then
+        assertEquals(dto1, dto2, "DTOs with same values should be equal");
+        assertNotEquals(dto1, dto3, "DTOs with different values should not be equal");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/CreateProjectDtoTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/CreateProjectDtoTest.java
@@ -1,0 +1,33 @@
+package de.tum.cit.aet.closed.ai.dto;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CreateProjectDtoTest {
+
+    @Test
+    void testCreateProjectDto() {
+        // Given
+        String name = "Test Project";
+        String color = "#FF5733";
+
+        // When
+        CreateProjectDto dto = new CreateProjectDto(name, color);
+
+        // Then
+        assertEquals(name, dto.name(), "Project name should match the input");
+        assertEquals(color, dto.color(), "Project color should match the input");
+    }
+
+    @Test
+    void testEquality() {
+        // Given
+        CreateProjectDto dto1 = new CreateProjectDto("Project 1", "#FF5733");
+        CreateProjectDto dto2 = new CreateProjectDto("Project 1", "#FF5733");
+        CreateProjectDto dto3 = new CreateProjectDto("Project 2", "#FF5733");
+
+        // Then
+        assertEquals(dto1, dto2, "DTOs with same values should be equal");
+        assertNotEquals(dto1, dto3, "DTOs with different values should not be equal");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/ProjectDtoTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/ProjectDtoTest.java
@@ -1,0 +1,92 @@
+package de.tum.cit.aet.closed.ai.dto;
+
+import de.tum.cit.aet.closed.ai.model.Project;
+import de.tum.cit.aet.closed.ai.model.Task;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProjectDtoTest {
+
+    @Test
+    void testProjectDtoConstructor() {
+        // Given
+        Long id = 1L;
+        String name = "Test Project";
+        String color = "#FF5733";
+        Instant createdAt = Instant.now();
+        Instant updatedAt = Instant.now();
+        List<Long> taskIds = List.of(1L, 2L, 3L);
+
+        // When
+        ProjectDto dto = new ProjectDto(id, name, color, createdAt, updatedAt, taskIds);
+
+        // Then
+        assertEquals(id, dto.id(), "ID should match");
+        assertEquals(name, dto.name(), "Name should match");
+        assertEquals(color, dto.color(), "Color should match");
+        assertEquals(createdAt, dto.createdAt(), "Created at should match");
+        assertEquals(updatedAt, dto.updatedAt(), "Updated at should match");
+        assertEquals(taskIds, dto.taskIds(), "Task IDs should match");
+    }
+
+    @Test
+    void testFromProject() {
+        // Given
+        Project project = new Project();
+        project.setId(1L);
+        project.setName("Project Name");
+        project.setColor("#00FF00");
+
+        Instant createdAt = Instant.now();
+        Instant updatedAt = Instant.now().plusSeconds(3600);
+        project.setCreatedAt(createdAt);
+        project.setUpdatedAt(updatedAt);
+
+        // Create tasks
+        List<Task> tasks = new ArrayList<>();
+
+        Task task1 = new Task();
+        task1.setId(101L);
+        tasks.add(task1);
+
+        Task task2 = new Task();
+        task2.setId(102L);
+        tasks.add(task2);
+
+        project.setTasks(tasks);
+
+        // When
+        ProjectDto dto = ProjectDto.fromProject(project);
+
+        // Then
+        assertEquals(project.getId(), dto.id(), "ID should match");
+        assertEquals(project.getName(), dto.name(), "Name should match");
+        assertEquals(project.getColor(), dto.color(), "Color should match");
+        assertEquals(project.getCreatedAt(), dto.createdAt(), "Created at should match");
+        assertEquals(project.getUpdatedAt(), dto.updatedAt(), "Updated at should match");
+
+        assertEquals(2, dto.taskIds().size(), "Should have 2 task IDs");
+        assertTrue(dto.taskIds().contains(101L), "Should contain task ID 101");
+        assertTrue(dto.taskIds().contains(102L), "Should contain task ID 102");
+    }
+
+    @Test
+    void testFromProjectWithNoTasks() {
+        // Given
+        Project project = new Project();
+        project.setId(1L);
+        project.setName("Empty Project");
+        project.setTasks(new ArrayList<>());
+
+        // When
+        ProjectDto dto = ProjectDto.fromProject(project);
+
+        // Then
+        assertEquals(0, dto.taskIds().size(), "Task IDs list should be empty");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/TaskDtoTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/TaskDtoTest.java
@@ -1,0 +1,100 @@
+package de.tum.cit.aet.closed.ai.dto;
+
+import de.tum.cit.aet.closed.ai.model.Task;
+import de.tum.cit.aet.closed.ai.model.TaskStatus;
+import de.tum.cit.aet.closed.ai.model.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskDtoTest {
+
+    @Test
+    void testTaskDtoConstructor() {
+        // Given
+        Long id = 1L;
+        String title = "Test Task";
+        String description = "Task Description";
+        TaskStatus status = TaskStatus.OPEN;
+        Instant createdAt = Instant.now();
+        Instant updatedAt = Instant.now();
+        List<String> comments = new ArrayList<>();
+        List<String> attachments = new ArrayList<>();
+        Long assigneeId = 3L;
+
+        // When
+        TaskDto dto = new TaskDto(id, title, description, status, createdAt, updatedAt,
+                comments, attachments, assigneeId);
+
+        // Then
+        assertEquals(id, dto.id(), "ID should match");
+        assertEquals(title, dto.title(), "Title should match");
+        assertEquals(description, dto.description(), "Description should match");
+        assertEquals(status, dto.taskStatus(), "Status should match");
+        assertEquals(createdAt, dto.createdAt(), "Created at should match");
+        assertEquals(updatedAt, dto.updatedAt(), "Updated at should match");
+        assertEquals(comments, dto.comments(), "Comments should match");
+        assertEquals(attachments, dto.attachments(), "Attachments should match");
+        assertEquals(assigneeId, dto.assigneeId(), "Assignee ID should match");
+    }
+
+    @Test
+    void testFromTask() {
+        // Given
+        Task task = new Task();
+        task.setId(1L);
+        task.setTitle("Task Title");
+        task.setDescription("Task Description");
+        task.setStatus(TaskStatus.IN_PROGRESS);
+
+        Instant createdAt = Instant.now();
+        Instant updatedAt = Instant.now().plusSeconds(3600);
+        task.setCreatedAt(createdAt);
+        task.setUpdatedAt(updatedAt);
+
+        List<String> comments = List.of("Comment 1", "Comment 2");
+        task.setComments(comments);
+
+        List<String> attachments = List.of("attachment1.pdf");
+        task.setAttachments(attachments);
+
+        User assignee = new User();
+        assignee.setId(5L);
+        task.setAssignee(assignee);
+
+        // When
+        TaskDto dto = TaskDto.fromTask(task);
+
+        // Then
+        assertEquals(task.getId(), dto.id(), "ID should match");
+        assertEquals(task.getTitle(), dto.title(), "Title should match");
+        assertEquals(task.getDescription(), dto.description(), "Description should match");
+        assertEquals(task.getStatus(), dto.taskStatus(), "Status should match");
+        assertEquals(task.getCreatedAt(), dto.createdAt(), "Created at should match");
+        assertEquals(task.getUpdatedAt(), dto.updatedAt(), "Updated at should match");
+        assertEquals(task.getComments(), dto.comments(), "Comments should match");
+        assertEquals(task.getAttachments(), dto.attachments(), "Attachments should match");
+        assertEquals(assignee.getId(), dto.assigneeId(), "Assignee ID should match");
+    }
+
+    @Test
+    void testFromTaskWithNullAssignee() {
+        // Given
+        Task task = new Task();
+        task.setId(1L);
+        task.setTitle("Task Title");
+        task.setDescription("Task Description");
+        task.setStatus(TaskStatus.OPEN);
+        task.setAssignee(null); // Null assignee
+
+        // When
+        TaskDto dto = TaskDto.fromTask(task);
+
+        // Then
+        assertNull(dto.assigneeId(), "Assignee ID should be null when task has no assignee");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/UserDtoTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/dto/UserDtoTest.java
@@ -1,0 +1,53 @@
+package de.tum.cit.aet.closed.ai.dto;
+
+import de.tum.cit.aet.closed.ai.model.User;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+
+class UserDtoTest {
+
+    @Test
+    void testUserDtoConstructor() {
+        // Given
+        Long id = 1L;
+        String name = "John Doe";
+        String profilePicture = "avatar.jpg";
+        Instant createdAt = Instant.now();
+        Instant updatedAt = Instant.now();
+
+        // When
+        UserDto dto = new UserDto(id, name, profilePicture, createdAt, updatedAt);
+
+        // Then
+        assertEquals(id, dto.id(), "ID should match");
+        assertEquals(name, dto.name(), "Name should match");
+        assertEquals(profilePicture, dto.profilePicture(), "Profile picture should match");
+        assertEquals(createdAt, dto.createdAt(), "Created at should match");
+        assertEquals(updatedAt, dto.updatedAt(), "Updated at should match");
+    }
+
+    @Test
+    void testFromUser() {
+        // Given
+        User user = new User();
+        user.setId(1L);
+        user.setName("Jane Smith");
+        user.setProfilePicture("profile.png");
+        Instant createdAt = Instant.now();
+        Instant updatedAt = Instant.now().plusSeconds(3600);
+        user.setCreatedAt(createdAt);
+        user.setUpdatedAt(updatedAt);
+
+        // When
+        UserDto dto = UserDto.fromUser(user);
+
+        // Then
+        assertEquals(user.getId(), dto.id(), "ID should match the user");
+        assertEquals(user.getName(), dto.name(), "Name should match the user");
+        assertEquals(user.getProfilePicture(), dto.profilePicture(), "Profile picture should match the user");
+        assertEquals(user.getCreatedAt(), dto.createdAt(), "Created at should match the user");
+        assertEquals(user.getUpdatedAt(), dto.updatedAt(), "Updated at should match the user");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/exception/ProjectNotFoundExceptionTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/exception/ProjectNotFoundExceptionTest.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.closed.ai.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProjectNotFoundExceptionTest {
+
+    @Test
+    void testExceptionMessage() {
+        // Given
+        String errorMessage = "Project not found with ID: 123";
+
+        // When
+        ProjectNotFoundException exception = new ProjectNotFoundException(errorMessage);
+
+        // Then
+        assertEquals(errorMessage, exception.getMessage(), "Exception message should match");
+    }
+
+    @Test
+    void testResponseStatusAnnotation() {
+        // Given
+        Class<ProjectNotFoundException> exceptionClass = ProjectNotFoundException.class;
+
+        // When
+        ResponseStatus annotation = exceptionClass.getAnnotation(ResponseStatus.class);
+
+        // Then
+        assertNotNull(annotation, "Class should have @ResponseStatus annotation");
+        assertEquals(HttpStatus.NOT_FOUND, annotation.value(),
+                "Exception should be mapped to HTTP 404 NOT_FOUND");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/exception/TaskNotFoundExceptionTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/exception/TaskNotFoundExceptionTest.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.closed.ai.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskNotFoundExceptionTest {
+
+    @Test
+    void testExceptionMessage() {
+        // Given
+        String errorMessage = "Task not found with ID: 123";
+
+        // When
+        TaskNotFoundException exception = new TaskNotFoundException(errorMessage);
+
+        // Then
+        assertEquals(errorMessage, exception.getMessage(), "Exception message should match");
+    }
+
+    @Test
+    void testResponseStatusAnnotation() {
+        // Given
+        Class<TaskNotFoundException> exceptionClass = TaskNotFoundException.class;
+
+        // When
+        ResponseStatus annotation = exceptionClass.getAnnotation(ResponseStatus.class);
+
+        // Then
+        assertNotNull(annotation, "Class should have @ResponseStatus annotation");
+        assertEquals(HttpStatus.NOT_FOUND, annotation.value(),
+                "Exception should be mapped to HTTP 404 NOT_FOUND");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/exception/UserNotFoundExceptionTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/exception/UserNotFoundExceptionTest.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.closed.ai.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserNotFoundExceptionTest {
+
+    @Test
+    void testExceptionMessage() {
+        // Given
+        String errorMessage = "User not found with ID: 123";
+
+        // When
+        UserNotFoundException exception = new UserNotFoundException(errorMessage);
+
+        // Then
+        assertEquals(errorMessage, exception.getMessage(), "Exception message should match");
+    }
+
+    @Test
+    void testResponseStatusAnnotation() {
+        // Given
+        Class<UserNotFoundException> exceptionClass = UserNotFoundException.class;
+
+        // When
+        ResponseStatus annotation = exceptionClass.getAnnotation(ResponseStatus.class);
+
+        // Then
+        assertNotNull(annotation, "Class should have @ResponseStatus annotation");
+        assertEquals(HttpStatus.NOT_FOUND, annotation.value(),
+                "Exception should be mapped to HTTP 404 NOT_FOUND");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/metrics/MetricsAspectTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/metrics/MetricsAspectTest.java
@@ -1,0 +1,74 @@
+package de.tum.cit.aet.closed.ai.metrics;
+
+import io.micrometer.core.instrument.Timer;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsAspectTest {
+
+    @Mock
+    private MetricsService metricsService;
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    @Mock
+    private Timer.Sample timerSample;
+
+    @Mock
+    private Timer timer;
+
+    private MetricsAspect metricsAspect;
+
+    @BeforeEach
+    void setUp() {
+        metricsAspect = new MetricsAspect(metricsService);
+    }
+
+    @Test
+    void testMeasureMethodExecutionTimeSuccess() throws Throwable {
+        // Given
+        Object expectedResult = new Object();
+        when(metricsService.startTimer()).thenReturn(timerSample);
+        when(metricsService.getRequestLatencyTimer()).thenReturn(timer);
+        when(joinPoint.proceed()).thenReturn(expectedResult);
+
+        // When
+        Object result = metricsAspect.measureMethodExecutionTime(joinPoint);
+
+        // Then
+        assertEquals(expectedResult, result, "Method should return the expected result");
+        verify(metricsService).startTimer();
+        verify(metricsService).incrementRequestCount();
+        verify(timerSample).stop(timer);
+        verify(metricsService, never()).incrementErrorCount();
+    }
+
+    @Test
+    void testMeasureMethodExecutionTimeWithException() throws Throwable {
+        // Given
+        RuntimeException expectedException = new RuntimeException("Test exception");
+        when(metricsService.startTimer()).thenReturn(timerSample);
+        when(metricsService.getRequestLatencyTimer()).thenReturn(timer);
+        when(joinPoint.proceed()).thenThrow(expectedException);
+
+        // When & Then
+        Exception exception = assertThrows(RuntimeException.class,
+                () -> metricsAspect.measureMethodExecutionTime(joinPoint),
+                "Method should propagate the exception");
+
+        assertEquals(expectedException, exception, "Should throw the original exception");
+        verify(metricsService).startTimer();
+        verify(metricsService).incrementRequestCount();
+        verify(metricsService).incrementErrorCount();
+        verify(timerSample).stop(timer);
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/metrics/MetricsServiceTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/metrics/MetricsServiceTest.java
@@ -1,0 +1,85 @@
+package de.tum.cit.aet.closed.ai.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetricsServiceTest {
+
+    private MeterRegistry meterRegistry;
+    private MetricsService metricsService;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        metricsService = new MetricsService(meterRegistry);
+    }
+
+    @Test
+    void testInitialization() {
+        // Verify that the meters have been registered with the registry
+        assertNotNull(meterRegistry.find("app_requests_total").counter());
+        assertNotNull(meterRegistry.find("app_requests_errors").counter());
+        assertNotNull(meterRegistry.find("app_request_latency").timer());
+    }
+
+    @Test
+    void testIncrementRequestCount() {
+        // Given
+        Counter counter = meterRegistry.find("app_requests_total").counter();
+        double initialCount = counter != null ? counter.count() : 0.0;
+
+        // When
+        metricsService.incrementRequestCount();
+
+        // Then
+        Counter updatedCounter = meterRegistry.find("app_requests_total").counter();
+        assertNotNull(updatedCounter);
+        assertEquals(initialCount + 1.0, updatedCounter.count(), "Request count should be incremented by 1");
+    }
+
+    @Test
+    void testIncrementErrorCount() {
+        // Given
+        Counter counter = meterRegistry.find("app_requests_errors").counter();
+        double initialCount = counter != null ? counter.count() : 0.0;
+
+        // When
+        metricsService.incrementErrorCount();
+
+        // Then
+        Counter updatedCounter = meterRegistry.find("app_requests_errors").counter();
+        assertNotNull(updatedCounter);
+        assertEquals(initialCount + 1.0, updatedCounter.count(), "Error count should be incremented by 1");
+    }
+
+    @Test
+    void testStartTimer() {
+        // When
+        Timer.Sample sample = metricsService.startTimer();
+
+        // Then
+        assertNotNull(sample, "Timer sample should not be null");
+
+        // Verify that stopping the timer records the timing
+        Timer timer = metricsService.getRequestLatencyTimer();
+        long count = timer.count();
+        sample.stop(timer);
+        assertEquals(count + 1, timer.count(), "Timer count should be incremented after stopping the sample");
+    }
+
+    @Test
+    void testGetRequestLatencyTimer() {
+        // When
+        Timer timer = metricsService.getRequestLatencyTimer();
+
+        // Then
+        assertNotNull(timer, "Request latency timer should not be null");
+        assertEquals("app_request_latency", timer.getId().getName(), "Timer should have the correct name");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/model/ProjectTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/model/ProjectTest.java
@@ -1,0 +1,33 @@
+package de.tum.cit.aet.closed.ai.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProjectTest {
+
+    @Test
+    void testCreateTask() {
+        // Given
+        Project project = new Project();
+        project.setId(1L);
+        project.setName("Test Project");
+        project.setColor("#FF5733");
+
+        String taskTitle = "Task Title";
+        String taskDesc = "Task Description";
+        TaskStatus taskStatus = TaskStatus.OPEN;
+
+        // When
+        Task task = project.createTask(taskTitle, taskDesc, taskStatus);
+
+        // Then
+        assertEquals(taskTitle, task.getTitle(), "Task title should match");
+        assertEquals(taskDesc, task.getDescription(), "Task description should match");
+        assertEquals(taskStatus, task.getStatus(), "Task status should match");
+        assertEquals(project, task.getProject(), "Task should be linked to the project");
+
+        // The task should be added to the project's tasks list
+        assertTrue(project.getTasks().contains(task), "Project should contain the created task");
+        assertEquals(1, project.getTasks().size(), "Project should have one task");
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/model/TaskStatusTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/model/TaskStatusTest.java
@@ -1,0 +1,28 @@
+package de.tum.cit.aet.closed.ai.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskStatusTest {
+
+    @Test
+    void testEnumValues() {
+        // Ensure all expected enum values exist
+        assertEquals(4, TaskStatus.values().length, "There should be 4 task statuses");
+
+        // Test specific enum values
+        assertEquals(TaskStatus.BACKLOG, TaskStatus.valueOf("BACKLOG"));
+        assertEquals(TaskStatus.OPEN, TaskStatus.valueOf("OPEN"));
+        assertEquals(TaskStatus.IN_PROGRESS, TaskStatus.valueOf("IN_PROGRESS"));
+        assertEquals(TaskStatus.DONE, TaskStatus.valueOf("DONE"));
+    }
+
+    @Test
+    void testEnumOrdinals() {
+        // Test ordinals to ensure the ordering remains as expected
+        assertEquals(0, TaskStatus.BACKLOG.ordinal());
+        assertEquals(1, TaskStatus.OPEN.ordinal());
+        assertEquals(2, TaskStatus.IN_PROGRESS.ordinal());
+        assertEquals(3, TaskStatus.DONE.ordinal());
+    }
+}

--- a/server/common/src/test/java/de/tum/cit/aet/closed/ai/model/TaskTest.java
+++ b/server/common/src/test/java/de/tum/cit/aet/closed/ai/model/TaskTest.java
@@ -1,0 +1,56 @@
+package de.tum.cit.aet.closed.ai.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskTest {
+
+    @Test
+    void testTaskGettersAndSetters() {
+        // Given
+        Task task = new Task();
+
+        // When
+        task.setId(1L);
+        task.setTitle("Task Title");
+        task.setDescription("Task Description");
+        task.setStatus(TaskStatus.IN_PROGRESS);
+
+        Project project = new Project();
+        project.setId(2L);
+        project.setName("Project Name");
+        task.setProject(project);
+
+        // Then
+        assertEquals(1L, task.getId(), "ID should match");
+        assertEquals("Task Title", task.getTitle(), "Title should match");
+        assertEquals("Task Description", task.getDescription(), "Description should match");
+        assertEquals(TaskStatus.IN_PROGRESS, task.getStatus(), "Status should match");
+        assertEquals(project, task.getProject(), "Project should match");
+    }
+
+    @Test
+    void testTaskStatusTransition() {
+        // Given
+        Task task = new Task();
+        task.setStatus(TaskStatus.BACKLOG);
+
+        // When
+        task.setStatus(TaskStatus.OPEN);
+
+        // Then
+        assertEquals(TaskStatus.OPEN, task.getStatus(), "Status should be updated");
+
+        // When
+        task.setStatus(TaskStatus.IN_PROGRESS);
+
+        // Then
+        assertEquals(TaskStatus.IN_PROGRESS, task.getStatus(), "Status should be updated to IN_PROGRESS");
+
+        // When
+        task.setStatus(TaskStatus.DONE);
+
+        // Then
+        assertEquals(TaskStatus.DONE, task.getStatus(), "Status should be updated to DONE");
+    }
+}

--- a/server/project-service/build.gradle
+++ b/server/project-service/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '7.1.0'
+    id 'jacoco'
 }
 
 group = 'de.tum.cit.aet.closed.ai'
@@ -45,4 +46,27 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.7
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/server/project-service/src/test/java/de/tum/cit/aet/closed/ai/ProjectServiceTest.java
+++ b/server/project-service/src/test/java/de/tum/cit/aet/closed/ai/ProjectServiceTest.java
@@ -1,0 +1,277 @@
+package de.tum.cit.aet.closed.ai;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import de.tum.cit.aet.closed.ai.client.UserServiceClient;
+import de.tum.cit.aet.closed.ai.exception.ProjectNotFoundException;
+import de.tum.cit.aet.closed.ai.metrics.ProjectMetrics;
+import de.tum.cit.aet.closed.ai.model.Project;
+import de.tum.cit.aet.closed.ai.model.Task;
+import de.tum.cit.aet.closed.ai.model.TaskStatus;
+import de.tum.cit.aet.closed.ai.model.User;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ProjectServiceTest {
+
+  @Mock private ProjectRepository projectRepository;
+
+  @Mock private UserServiceClient userServiceClient;
+
+  @Mock private ProjectMetrics projectMetrics;
+
+  @InjectMocks private ProjectService projectService;
+
+  private Project testProject1;
+  private Project testProject2;
+  private User testUser;
+  private Task testTask;
+
+  @BeforeEach
+  void setUp() {
+    // Create test user
+    testUser = new User();
+    testUser.setId(1L);
+    testUser.setName("Test User");
+
+    // Create test projects
+    testProject1 = new Project();
+    testProject1.setId(1L);
+    testProject1.setName("Test Project 1");
+    testProject1.setColor("#FF0000");
+
+    testProject2 = new Project();
+    testProject2.setId(2L);
+    testProject2.setName("Test Project 2");
+    testProject2.setColor("#00FF00");
+
+    // Create test task
+    testTask = new Task();
+    testTask.setId(1L);
+    testTask.setTitle("Test Task");
+    testTask.setDescription("Test Description");
+    testTask.setStatus(TaskStatus.OPEN);
+    testTask.setProject(testProject1);
+    testTask.setAssignee(testUser);
+
+    testProject1.getTasks().add(testTask);
+  }
+
+  @Test
+  void findAll_ShouldReturnAllProjects() {
+    // Arrange
+    List<Project> expectedProjects = Arrays.asList(testProject1, testProject2);
+    when(projectRepository.findAll()).thenReturn(expectedProjects);
+
+    // Act
+    List<Project> actualProjects = projectService.findAll();
+
+    // Assert
+    assertEquals(expectedProjects, actualProjects);
+    verify(projectRepository).findAll();
+  }
+
+  @Test
+  void findById_WhenProjectExists_ShouldReturnProject() {
+    // Arrange
+    when(projectRepository.findById(1L)).thenReturn(Optional.of(testProject1));
+
+    // Act
+    Optional<Project> result = projectService.findById(1L);
+
+    // Assert
+    assertTrue(result.isPresent());
+    assertEquals(testProject1, result.get());
+    verify(projectRepository).findById(1L);
+  }
+
+  @Test
+  void save_ShouldSaveAndReturnProject() {
+    // Arrange
+    when(projectRepository.save(testProject1)).thenReturn(testProject1);
+
+    // Act
+    Project savedProject = projectService.save(testProject1);
+
+    // Assert
+    assertEquals(testProject1, savedProject);
+    verify(projectRepository).save(testProject1);
+  }
+
+  @Test
+  void delete_WhenProjectExists_ShouldCallRepositoryAndUpdateMetrics() {
+    // Arrange
+    when(projectRepository.findById(1L)).thenReturn(Optional.of(testProject1));
+
+    // Act
+    projectService.delete(1L);
+
+    // Assert
+    verify(projectRepository).findById(1L);
+    verify(projectRepository).deleteById(1L);
+    verify(projectMetrics).incrementProjectsDeleted();
+  }
+
+  @Test
+  void delete_WhenProjectDoesNotExist_ShouldThrowException() {
+    // Arrange
+    when(projectRepository.findById(99L)).thenReturn(Optional.empty());
+
+    // Act & Assert
+    assertThrows(ProjectNotFoundException.class, () -> projectService.delete(99L));
+    verify(projectRepository).findById(99L);
+    verify(projectRepository, never()).deleteById(anyLong());
+    verify(projectMetrics, never()).incrementProjectsDeleted();
+  }
+
+  @Test
+  void createProject_ShouldCreateAndSaveProject() {
+    // Arrange
+    String projectName = "New Project";
+    String projectColor = "#0000FF";
+    Project newProject = new Project();
+    newProject.setName(projectName);
+    newProject.setColor(projectColor);
+
+    when(projectRepository.save(any(Project.class))).thenReturn(newProject);
+
+    // Act
+    Project createdProject = projectService.createProject(projectName, projectColor);
+
+    // Assert
+    assertEquals(projectName, createdProject.getName());
+    assertEquals(projectColor, createdProject.getColor());
+    verify(projectRepository).save(any(Project.class));
+    verify(projectMetrics).incrementProjectsCreated();
+  }
+
+  @Test
+  void createTask_WhenProjectExistsAndNoAssignee_ShouldCreateTask() {
+    // Arrange
+    String taskTitle = "New Task";
+    String taskDesc = "New Description";
+    TaskStatus taskStatus = TaskStatus.OPEN;
+
+    Project projectWithTask = new Project();
+    projectWithTask.setId(1L);
+    projectWithTask.setName("Test Project");
+    projectWithTask.createTask(taskTitle, taskDesc, taskStatus);
+
+    when(projectRepository.findById(1L))
+        .thenReturn(Optional.of(testProject1))
+        .thenReturn(Optional.of(projectWithTask));
+
+    // Act
+    Task createdTask = projectService.createTask(1L, taskTitle, taskDesc, taskStatus, null);
+
+    // Assert
+    assertNotNull(createdTask);
+    assertEquals(taskTitle, createdTask.getTitle());
+    assertEquals(taskDesc, createdTask.getDescription());
+    assertEquals(taskStatus, createdTask.getStatus());
+    verify(projectRepository, times(2)).findById(1L);
+    verify(projectMetrics).incrementTasksCreated();
+    verify(userServiceClient, never()).findById(anyLong());
+  }
+
+  @Test
+  void createTask_WhenProjectExistsAndAssigneeExists_ShouldCreateTaskWithAssignee() {
+    // Arrange
+    String taskTitle = "New Task";
+    String taskDesc = "New Description";
+    TaskStatus taskStatus = TaskStatus.OPEN;
+    Long assigneeId = 1L;
+
+    Project projectWithTask = new Project();
+    projectWithTask.setId(1L);
+    projectWithTask.setName("Test Project");
+    Task newTask = projectWithTask.createTask(taskTitle, taskDesc, taskStatus);
+    newTask.setAssignee(testUser);
+
+    when(projectRepository.findById(1L))
+        .thenReturn(Optional.of(testProject1))
+        .thenReturn(Optional.of(projectWithTask));
+
+    when(userServiceClient.findById(assigneeId))
+        .thenReturn(
+            Optional.of(
+                new de.tum.cit.aet.closed.ai.dto.UserDto(
+                    testUser.getId(),
+                    testUser.getName(),
+                    testUser.getProfilePicture(),
+                    null,
+                    null)));
+
+    // Act
+    Task createdTask = projectService.createTask(1L, taskTitle, taskDesc, taskStatus, assigneeId);
+
+    // Assert
+    assertNotNull(createdTask);
+    assertEquals(taskTitle, createdTask.getTitle());
+    assertEquals(taskDesc, createdTask.getDescription());
+    assertEquals(taskStatus, createdTask.getStatus());
+    assertNotNull(createdTask.getAssignee());
+    assertEquals(assigneeId, createdTask.getAssignee().getId());
+    verify(projectRepository, times(2)).findById(1L);
+    verify(projectMetrics).incrementTasksCreated();
+    verify(userServiceClient).findById(assigneeId);
+  }
+
+  @Test
+  void createTask_WhenProjectDoesNotExist_ShouldThrowException() {
+    // Arrange
+    String taskTitle = "New Task";
+    String taskDesc = "New Description";
+    TaskStatus taskStatus = TaskStatus.OPEN;
+    when(projectRepository.findById(99L)).thenReturn(Optional.empty());
+
+    // Act & Assert
+    assertThrows(
+        ProjectNotFoundException.class,
+        () -> projectService.createTask(99L, taskTitle, taskDesc, taskStatus, null));
+    verify(projectRepository).findById(99L);
+    verify(projectMetrics, never()).incrementTasksCreated();
+  }
+
+  @Test
+  void createTask_WhenAssigneeDoesNotExist_ShouldCreateTaskWithoutAssignee() {
+    // Arrange
+    String taskTitle = "New Task";
+    String taskDesc = "New Description";
+    TaskStatus taskStatus = TaskStatus.OPEN;
+    Long assigneeId = 99L;
+
+    Project projectWithTask = new Project();
+    projectWithTask.setId(1L);
+    projectWithTask.setName("Test Project");
+    projectWithTask.createTask(taskTitle, taskDesc, taskStatus);
+
+    when(projectRepository.findById(1L))
+        .thenReturn(Optional.of(testProject1))
+        .thenReturn(Optional.of(projectWithTask));
+
+    when(userServiceClient.findById(assigneeId)).thenReturn(Optional.empty());
+
+    // Act
+    Task createdTask = projectService.createTask(1L, taskTitle, taskDesc, taskStatus, assigneeId);
+
+    // Assert
+    assertNotNull(createdTask);
+    assertEquals(taskTitle, createdTask.getTitle());
+    assertEquals(taskDesc, createdTask.getDescription());
+    assertEquals(taskStatus, createdTask.getStatus());
+    assertNull(createdTask.getAssignee());
+    verify(projectRepository, times(2)).findById(1L);
+    verify(projectMetrics).incrementTasksCreated();
+    verify(userServiceClient).findById(assigneeId);
+  }
+}

--- a/server/project-service/src/test/java/de/tum/cit/aet/closed/ai/metrics/ProjectMetricsTest.java
+++ b/server/project-service/src/test/java/de/tum/cit/aet/closed/ai/metrics/ProjectMetricsTest.java
@@ -1,0 +1,63 @@
+package de.tum.cit.aet.closed.ai.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ProjectMetricsTest {
+
+  private MeterRegistry registry;
+  private ProjectMetrics projectMetrics;
+
+  @BeforeEach
+  public void setUp() {
+    registry = new SimpleMeterRegistry();
+    projectMetrics = new ProjectMetrics(registry);
+  }
+
+  @Test
+  public void testIncrementProjectsCreated() {
+    // Arrange & Act
+    projectMetrics.incrementProjectsCreated();
+
+    // Assert
+    Counter counter = registry.find("projects_created_total").counter();
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  public void testIncrementProjectsDeleted() {
+    // Arrange & Act
+    projectMetrics.incrementProjectsDeleted();
+
+    // Assert
+    Counter counter = registry.find("projects_deleted_total").counter();
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  public void testIncrementTasksCreated() {
+    // Arrange & Act
+    projectMetrics.incrementTasksCreated();
+
+    // Assert
+    Counter counter = registry.find("tasks_created_total").counter();
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  public void testMultipleIncrements() {
+    // Arrange & Act
+    projectMetrics.incrementProjectsCreated();
+    projectMetrics.incrementProjectsCreated();
+    projectMetrics.incrementProjectsCreated();
+
+    // Assert
+    Counter counter = registry.find("projects_created_total").counter();
+    assertEquals(3.0, counter.count());
+  }
+}

--- a/server/task-service/build.gradle
+++ b/server/task-service/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '7.1.0'
+    id 'jacoco'
 }
 
 group = 'de.tum.cit.aet.closed.ai'
@@ -46,4 +47,27 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.7
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/server/task-service/src/test/java/de/tum/cit/aet/closed/ai/ApplicationTest.java
+++ b/server/task-service/src/test/java/de/tum/cit/aet/closed/ai/ApplicationTest.java
@@ -1,0 +1,11 @@
+package de.tum.cit.aet.closed.ai;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTest {
+
+  @Test
+  void contextLoads() {}
+}

--- a/server/task-service/src/test/java/de/tum/cit/aet/closed/ai/TaskServiceTest.java
+++ b/server/task-service/src/test/java/de/tum/cit/aet/closed/ai/TaskServiceTest.java
@@ -1,0 +1,158 @@
+package de.tum.cit.aet.closed.ai;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import de.tum.cit.aet.closed.ai.exception.TaskNotFoundException;
+import de.tum.cit.aet.closed.ai.metrics.TaskMetrics;
+import de.tum.cit.aet.closed.ai.model.Project;
+import de.tum.cit.aet.closed.ai.model.Task;
+import de.tum.cit.aet.closed.ai.model.TaskStatus;
+import de.tum.cit.aet.closed.ai.model.User;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private TaskMetrics taskMetrics;
+
+    @InjectMocks
+    private TaskService taskService;
+
+    private Task testTask1;
+    private Task testTask2;
+    private User testUser;
+    private Project testProject;
+
+    @BeforeEach
+    void setUp() {
+        // Create test user
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setName("Test User");
+
+        // Create test project
+        testProject = new Project();
+        testProject.setId(1L);
+        testProject.setName("Test Project");
+
+        // Create test tasks
+        testTask1 = new Task();
+        testTask1.setId(1L);
+        testTask1.setTitle("Test Task 1");
+        testTask1.setDescription("Description 1");
+        testTask1.setStatus(TaskStatus.OPEN);
+        testTask1.setAssignee(testUser);
+        testTask1.setProject(testProject);
+
+        testTask2 = new Task();
+        testTask2.setId(2L);
+        testTask2.setTitle("Test Task 2");
+        testTask2.setDescription("Description 2");
+        testTask2.setStatus(TaskStatus.IN_PROGRESS);
+        testTask2.setAssignee(testUser);
+        testTask2.setProject(testProject);
+    }
+
+    @Test
+    void findAll_ShouldReturnAllTasks() {
+        // Arrange
+        List<Task> expectedTasks = Arrays.asList(testTask1, testTask2);
+        when(taskRepository.findAll()).thenReturn(expectedTasks);
+
+        // Act
+        List<Task> actualTasks = taskService.findAll();
+
+        // Assert
+        assertEquals(expectedTasks, actualTasks);
+        verify(taskRepository).findAll();
+    }
+
+    @Test
+    void findById_WhenTaskExists_ShouldReturnTask() {
+        // Arrange
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(testTask1));
+
+        // Act
+        Optional<Task> result = taskService.findById(1L);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(testTask1, result.get());
+        verify(taskRepository).findById(1L);
+    }
+
+    @Test
+    void save_ShouldSaveAndReturnTask() {
+        // Arrange
+        when(taskRepository.save(testTask1)).thenReturn(testTask1);
+
+        // Act
+        Task savedTask = taskService.save(testTask1);
+
+        // Assert
+        assertEquals(testTask1, savedTask);
+        verify(taskRepository).save(testTask1);
+    }
+
+    @Test
+    void delete_ShouldCallRepositoryAndUpdateMetrics() {
+        // Act
+        taskService.delete(1L);
+
+        // Assert
+        verify(taskRepository).deleteById(1L);
+        verify(taskMetrics).incrementTasksDeleted();
+    }
+
+    @Test
+    void findByStatus_ShouldReturnTasksWithGivenStatus() {
+        // Arrange
+        List<Task> expectedTasks = List.of(testTask1);
+        when(taskRepository.findByStatus(TaskStatus.OPEN)).thenReturn(expectedTasks);
+
+        // Act
+        List<Task> actualTasks = taskService.findByStatus(TaskStatus.OPEN);
+
+        // Assert
+        assertEquals(expectedTasks, actualTasks);
+        verify(taskRepository).findByStatus(TaskStatus.OPEN);
+    }
+
+    @Test
+    void setStatus_WhenTaskExists_ShouldUpdateStatus() {
+        // Arrange
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(testTask1));
+        when(taskRepository.save(testTask1)).thenReturn(testTask1);
+
+        // Act
+        Task updatedTask = taskService.setStatus(1L, TaskStatus.DONE);
+
+        // Assert
+        assertEquals(TaskStatus.DONE, updatedTask.getStatus());
+        verify(taskRepository).findById(1L);
+        verify(taskRepository).save(testTask1);
+    }
+
+    @Test
+    void setStatus_WhenTaskDoesNotExist_ShouldThrowException() {
+        // Arrange
+        when(taskRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(TaskNotFoundException.class, () -> taskService.setStatus(99L, TaskStatus.DONE));
+        verify(taskRepository).findById(99L);
+        verify(taskRepository, never()).save(any(Task.class));
+    }
+}

--- a/server/task-service/src/test/java/de/tum/cit/aet/closed/ai/TaskServiceTest.java
+++ b/server/task-service/src/test/java/de/tum/cit/aet/closed/ai/TaskServiceTest.java
@@ -22,137 +22,134 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class TaskServiceTest {
 
-    @Mock
-    private TaskRepository taskRepository;
-    @Mock
-    private TaskMetrics taskMetrics;
+  @Mock private TaskRepository taskRepository;
+  @Mock private TaskMetrics taskMetrics;
 
-    @InjectMocks
-    private TaskService taskService;
+  @InjectMocks private TaskService taskService;
 
-    private Task testTask1;
-    private Task testTask2;
-    private User testUser;
-    private Project testProject;
+  private Task testTask1;
+  private Task testTask2;
+  private User testUser;
+  private Project testProject;
 
-    @BeforeEach
-    void setUp() {
-        // Create test user
-        testUser = new User();
-        testUser.setId(1L);
-        testUser.setName("Test User");
+  @BeforeEach
+  void setUp() {
+    // Create test user
+    testUser = new User();
+    testUser.setId(1L);
+    testUser.setName("Test User");
 
-        // Create test project
-        testProject = new Project();
-        testProject.setId(1L);
-        testProject.setName("Test Project");
+    // Create test project
+    testProject = new Project();
+    testProject.setId(1L);
+    testProject.setName("Test Project");
 
-        // Create test tasks
-        testTask1 = new Task();
-        testTask1.setId(1L);
-        testTask1.setTitle("Test Task 1");
-        testTask1.setDescription("Description 1");
-        testTask1.setStatus(TaskStatus.OPEN);
-        testTask1.setAssignee(testUser);
-        testTask1.setProject(testProject);
+    // Create test tasks
+    testTask1 = new Task();
+    testTask1.setId(1L);
+    testTask1.setTitle("Test Task 1");
+    testTask1.setDescription("Description 1");
+    testTask1.setStatus(TaskStatus.OPEN);
+    testTask1.setAssignee(testUser);
+    testTask1.setProject(testProject);
 
-        testTask2 = new Task();
-        testTask2.setId(2L);
-        testTask2.setTitle("Test Task 2");
-        testTask2.setDescription("Description 2");
-        testTask2.setStatus(TaskStatus.IN_PROGRESS);
-        testTask2.setAssignee(testUser);
-        testTask2.setProject(testProject);
-    }
+    testTask2 = new Task();
+    testTask2.setId(2L);
+    testTask2.setTitle("Test Task 2");
+    testTask2.setDescription("Description 2");
+    testTask2.setStatus(TaskStatus.IN_PROGRESS);
+    testTask2.setAssignee(testUser);
+    testTask2.setProject(testProject);
+  }
 
-    @Test
-    void findAll_ShouldReturnAllTasks() {
-        // Arrange
-        List<Task> expectedTasks = Arrays.asList(testTask1, testTask2);
-        when(taskRepository.findAll()).thenReturn(expectedTasks);
+  @Test
+  void findAll_ShouldReturnAllTasks() {
+    // Arrange
+    List<Task> expectedTasks = Arrays.asList(testTask1, testTask2);
+    when(taskRepository.findAll()).thenReturn(expectedTasks);
 
-        // Act
-        List<Task> actualTasks = taskService.findAll();
+    // Act
+    List<Task> actualTasks = taskService.findAll();
 
-        // Assert
-        assertEquals(expectedTasks, actualTasks);
-        verify(taskRepository).findAll();
-    }
+    // Assert
+    assertEquals(expectedTasks, actualTasks);
+    verify(taskRepository).findAll();
+  }
 
-    @Test
-    void findById_WhenTaskExists_ShouldReturnTask() {
-        // Arrange
-        when(taskRepository.findById(1L)).thenReturn(Optional.of(testTask1));
+  @Test
+  void findById_WhenTaskExists_ShouldReturnTask() {
+    // Arrange
+    when(taskRepository.findById(1L)).thenReturn(Optional.of(testTask1));
 
-        // Act
-        Optional<Task> result = taskService.findById(1L);
+    // Act
+    Optional<Task> result = taskService.findById(1L);
 
-        // Assert
-        assertTrue(result.isPresent());
-        assertEquals(testTask1, result.get());
-        verify(taskRepository).findById(1L);
-    }
+    // Assert
+    assertTrue(result.isPresent());
+    assertEquals(testTask1, result.get());
+    verify(taskRepository).findById(1L);
+  }
 
-    @Test
-    void save_ShouldSaveAndReturnTask() {
-        // Arrange
-        when(taskRepository.save(testTask1)).thenReturn(testTask1);
+  @Test
+  void save_ShouldSaveAndReturnTask() {
+    // Arrange
+    when(taskRepository.save(testTask1)).thenReturn(testTask1);
 
-        // Act
-        Task savedTask = taskService.save(testTask1);
+    // Act
+    Task savedTask = taskService.save(testTask1);
 
-        // Assert
-        assertEquals(testTask1, savedTask);
-        verify(taskRepository).save(testTask1);
-    }
+    // Assert
+    assertEquals(testTask1, savedTask);
+    verify(taskRepository).save(testTask1);
+  }
 
-    @Test
-    void delete_ShouldCallRepositoryAndUpdateMetrics() {
-        // Act
-        taskService.delete(1L);
+  @Test
+  void delete_ShouldCallRepositoryAndUpdateMetrics() {
+    // Act
+    taskService.delete(1L);
 
-        // Assert
-        verify(taskRepository).deleteById(1L);
-        verify(taskMetrics).incrementTasksDeleted();
-    }
+    // Assert
+    verify(taskRepository).deleteById(1L);
+    verify(taskMetrics).incrementTasksDeleted();
+  }
 
-    @Test
-    void findByStatus_ShouldReturnTasksWithGivenStatus() {
-        // Arrange
-        List<Task> expectedTasks = List.of(testTask1);
-        when(taskRepository.findByStatus(TaskStatus.OPEN)).thenReturn(expectedTasks);
+  @Test
+  void findByStatus_ShouldReturnTasksWithGivenStatus() {
+    // Arrange
+    List<Task> expectedTasks = List.of(testTask1);
+    when(taskRepository.findByStatus(TaskStatus.OPEN)).thenReturn(expectedTasks);
 
-        // Act
-        List<Task> actualTasks = taskService.findByStatus(TaskStatus.OPEN);
+    // Act
+    List<Task> actualTasks = taskService.findByStatus(TaskStatus.OPEN);
 
-        // Assert
-        assertEquals(expectedTasks, actualTasks);
-        verify(taskRepository).findByStatus(TaskStatus.OPEN);
-    }
+    // Assert
+    assertEquals(expectedTasks, actualTasks);
+    verify(taskRepository).findByStatus(TaskStatus.OPEN);
+  }
 
-    @Test
-    void setStatus_WhenTaskExists_ShouldUpdateStatus() {
-        // Arrange
-        when(taskRepository.findById(1L)).thenReturn(Optional.of(testTask1));
-        when(taskRepository.save(testTask1)).thenReturn(testTask1);
+  @Test
+  void setStatus_WhenTaskExists_ShouldUpdateStatus() {
+    // Arrange
+    when(taskRepository.findById(1L)).thenReturn(Optional.of(testTask1));
+    when(taskRepository.save(testTask1)).thenReturn(testTask1);
 
-        // Act
-        Task updatedTask = taskService.setStatus(1L, TaskStatus.DONE);
+    // Act
+    Task updatedTask = taskService.setStatus(1L, TaskStatus.DONE);
 
-        // Assert
-        assertEquals(TaskStatus.DONE, updatedTask.getStatus());
-        verify(taskRepository).findById(1L);
-        verify(taskRepository).save(testTask1);
-    }
+    // Assert
+    assertEquals(TaskStatus.DONE, updatedTask.getStatus());
+    verify(taskRepository).findById(1L);
+    verify(taskRepository).save(testTask1);
+  }
 
-    @Test
-    void setStatus_WhenTaskDoesNotExist_ShouldThrowException() {
-        // Arrange
-        when(taskRepository.findById(99L)).thenReturn(Optional.empty());
+  @Test
+  void setStatus_WhenTaskDoesNotExist_ShouldThrowException() {
+    // Arrange
+    when(taskRepository.findById(99L)).thenReturn(Optional.empty());
 
-        // Act & Assert
-        assertThrows(TaskNotFoundException.class, () -> taskService.setStatus(99L, TaskStatus.DONE));
-        verify(taskRepository).findById(99L);
-        verify(taskRepository, never()).save(any(Task.class));
-    }
+    // Act & Assert
+    assertThrows(TaskNotFoundException.class, () -> taskService.setStatus(99L, TaskStatus.DONE));
+    verify(taskRepository).findById(99L);
+    verify(taskRepository, never()).save(any(Task.class));
+  }
 }

--- a/server/task-service/src/test/java/de/tum/cit/aet/closed/ai/metrics/TaskMetricsTest.java
+++ b/server/task-service/src/test/java/de/tum/cit/aet/closed/ai/metrics/TaskMetricsTest.java
@@ -1,0 +1,42 @@
+package de.tum.cit.aet.closed.ai.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TaskMetricsTest {
+
+  private MeterRegistry registry;
+  private TaskMetrics taskMetrics;
+
+  @BeforeEach
+  public void setUp() {
+    registry = new SimpleMeterRegistry();
+    taskMetrics = new TaskMetrics(registry);
+  }
+
+  @Test
+  public void testIncrementTasksDeleted() {
+    // Arrange & Act
+    taskMetrics.incrementTasksDeleted();
+
+    // Assert
+    Counter counter = registry.find("tasks_deleted_total").counter();
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  public void testMultipleIncrements() {
+    // Arrange & Act
+    taskMetrics.incrementTasksDeleted();
+    taskMetrics.incrementTasksDeleted();
+
+    // Assert
+    Counter counter = registry.find("tasks_deleted_total").counter();
+    assertEquals(2.0, counter.count());
+  }
+}

--- a/server/user-service/build.gradle
+++ b/server/user-service/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '7.1.0'
+    id 'jacoco'
 }
 
 group = 'de.tum.cit.aet.closed.ai'
@@ -46,4 +47,27 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.7
+            }
+        }
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/server/user-service/src/test/java/de/tum/cit/aet/closed/ai/ApplicationTest.java
+++ b/server/user-service/src/test/java/de/tum/cit/aet/closed/ai/ApplicationTest.java
@@ -1,0 +1,11 @@
+package de.tum.cit.aet.closed.ai;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTest {
+
+  @Test
+  void contextLoads() {}
+}

--- a/server/user-service/src/test/java/de/tum/cit/aet/closed/ai/UserServiceTest.java
+++ b/server/user-service/src/test/java/de/tum/cit/aet/closed/ai/UserServiceTest.java
@@ -1,0 +1,137 @@
+package de.tum.cit.aet.closed.ai;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import de.tum.cit.aet.closed.ai.metrics.UserMetrics;
+import de.tum.cit.aet.closed.ai.model.User;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private UserMetrics userMetrics;
+
+  @InjectMocks private UserService userService;
+
+  private User testUser1;
+  private User testUser2;
+
+  @BeforeEach
+  void setUp() {
+    // Create test users
+    testUser1 = new User();
+    testUser1.setId(1L);
+    testUser1.setName("Test User 1");
+    testUser1.setProfilePicture("profile1.jpg");
+
+    testUser2 = new User();
+    testUser2.setId(2L);
+    testUser2.setName("Test User 2");
+    testUser2.setProfilePicture("profile2.jpg");
+  }
+
+  @Test
+  void findAll_ShouldReturnAllUsers() {
+    // Arrange
+    List<User> expectedUsers = Arrays.asList(testUser1, testUser2);
+    when(userRepository.findAll()).thenReturn(expectedUsers);
+
+    // Act
+    List<User> actualUsers = userService.findAll();
+
+    // Assert
+    assertEquals(expectedUsers, actualUsers);
+    verify(userRepository).findAll();
+  }
+
+  @Test
+  void findById_WhenUserExists_ShouldReturnUser() {
+    // Arrange
+    when(userRepository.findById(1L)).thenReturn(Optional.of(testUser1));
+
+    // Act
+    Optional<User> result = userService.findById(1L);
+
+    // Assert
+    assertTrue(result.isPresent());
+    assertEquals(testUser1, result.get());
+    verify(userRepository).findById(1L);
+  }
+
+  @Test
+  void findById_WhenUserDoesNotExist_ShouldReturnEmpty() {
+    // Arrange
+    when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+    // Act
+    Optional<User> result = userService.findById(99L);
+
+    // Assert
+    assertFalse(result.isPresent());
+    verify(userRepository).findById(99L);
+  }
+
+  @Test
+  void save_ShouldSaveAndReturnUser() {
+    // Arrange
+    when(userRepository.save(testUser1)).thenReturn(testUser1);
+
+    // Act
+    User savedUser = userService.save(testUser1);
+
+    // Assert
+    assertEquals(testUser1, savedUser);
+    verify(userRepository).save(testUser1);
+  }
+
+  @Test
+  void delete_ShouldCallRepositoryAndUpdateMetrics() {
+    // Act
+    userService.delete(1L);
+
+    // Assert
+    verify(userRepository).deleteById(1L);
+    verify(userMetrics).incrementUsersDeleted();
+  }
+
+  @Test
+  void create_ShouldCreateUserAndUpdateMetrics() {
+    // Arrange
+    String userName = "New User";
+    String profilePicture = "new_profile.jpg";
+
+    User newUser = new User();
+    newUser.setName(userName);
+    newUser.setProfilePicture(profilePicture);
+
+    when(userRepository.save(any(User.class)))
+        .thenAnswer(
+            invocation -> {
+              User user = invocation.getArgument(0);
+              user.setId(3L);
+              return user;
+            });
+
+    // Act
+    User createdUser = userService.create(userName, profilePicture);
+
+    // Assert
+    assertNotNull(createdUser);
+    assertEquals(userName, createdUser.getName());
+    assertEquals(profilePicture, createdUser.getProfilePicture());
+    assertNotNull(createdUser.getId());
+    verify(userRepository).save(any(User.class));
+    verify(userMetrics).incrementUsersCreated();
+  }
+}

--- a/server/user-service/src/test/java/de/tum/cit/aet/closed/ai/metrics/UserMetricsTest.java
+++ b/server/user-service/src/test/java/de/tum/cit/aet/closed/ai/metrics/UserMetricsTest.java
@@ -1,0 +1,59 @@
+package de.tum.cit.aet.closed.ai.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UserMetricsTest {
+
+  private MeterRegistry registry;
+  private UserMetrics userMetrics;
+
+  @BeforeEach
+  public void setUp() {
+    registry = new SimpleMeterRegistry();
+    userMetrics = new UserMetrics(registry);
+  }
+
+  @Test
+  public void testIncrementUsersCreated() {
+    // Arrange & Act
+    userMetrics.incrementUsersCreated();
+
+    // Assert
+    Counter counter = registry.find("users_created_total").counter();
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  public void testIncrementUsersDeleted() {
+    // Arrange & Act
+    userMetrics.incrementUsersDeleted();
+
+    // Assert
+    Counter counter = registry.find("users_deleted_total").counter();
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  public void testMultipleIncrements() {
+    // Arrange & Act
+    userMetrics.incrementUsersCreated();
+    userMetrics.incrementUsersCreated();
+
+    userMetrics.incrementUsersDeleted();
+    userMetrics.incrementUsersDeleted();
+    userMetrics.incrementUsersDeleted();
+
+    // Assert
+    Counter createdCounter = registry.find("users_created_total").counter();
+    assertEquals(2.0, createdCounter.count());
+
+    Counter deletedCounter = registry.find("users_deleted_total").counter();
+    assertEquals(3.0, deletedCounter.count());
+  }
+}


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the testing framework, code coverage reporting, and the addition of unit tests. The changes enhance server test coverage and enforce minimum coverage thresholds.

### Testing and Code Coverage Enhancements:
* Updated `.github/workflows/test.yml` to include steps for generating and uploading JaCoCo code coverage reports. This ensures coverage data is available for analysis.
* Added the `jacoco` plugin in `server/<modules>/build.gradle` and configured tasks for generating coverage reports and enforcing a minimum coverage threshold of 70% in all submodules.
