### PR TITLE
`Deployment`: Add k8s Deployment to GitHub's Deployment Section

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: k8s
+      url: https://closed-ai.student.k8s.aet.cit.tum.de
     # Only run if the build workflow succeeded (when triggered by workflow_run)
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:


### PR DESCRIPTION
This pull request adds an `environment` block to specify the deployment environment for the `deploy` job.

This will add the deployment similar to how it is done for the AWS deployment:
<img width="346" height="91" alt="Bildschirmfoto 2025-07-18 um 13 47 52" src="https://github.com/user-attachments/assets/7ed367af-e506-4ec9-9aec-19220060ddae" />
